### PR TITLE
Fix DB init indentation error

### DIFF
--- a/app.py
+++ b/app.py
@@ -47,8 +47,15 @@ def verify_password(password: str) -> bool:
 def init_database():
     """Initialise database connection and create tables"""
     try:
+        # Prefer Streamlit secrets but allow an env var fallback
+        database_url = st.secrets.get("database", {}).get("url") or os.getenv("DATABASE_URL")
+        if not database_url:
+            st.error(
+                "Database URL not configured. Set database.url in Streamlit secrets "
+                "or the DATABASE_URL environment variable."
+            )
             return None
-        
+
         engine = create_engine(database_url)
         
         # Create table if it doesn't exist


### PR DESCRIPTION
## Summary
- fix indentation in `init_database`
- ensure database URL pulled from secrets or environment variable

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68875058b2408323a542c9396d0aa9a2