### PR TITLE
Fix auth token validation

### DIFF
--- a/app.py
+++ b/app.py
@@ -293,7 +293,7 @@ def authenticate_ip(engine, ip_address):
 
 def is_token_authenticated(engine, token):
     """Check if auth token is valid within 24 hours"""
-    if not token:
+    if not token or not isinstance(token, str):
         return False
     try:
         with engine.connect() as conn:
@@ -358,7 +358,7 @@ def set_auth_cookie(token):
 
 def get_auth_cookie():
     """Retrieve auth token from browser cookies"""
-    return components.html(
+    token = components.html(
         """
         <script>
         const match = document.cookie.match(new RegExp('(^| )auth_token=([^;]+)'));
@@ -367,7 +367,13 @@ def get_auth_cookie():
         </script>
         """,
         height=0,
+        key="auth_cookie",
     )
+
+    # components.html may return a DeltaGenerator object while the browser
+    # sends back the actual token value asynchronously.  Ensure we only
+    # return a string to avoid passing unsupported objects to SQLAlchemy.
+    return token if isinstance(token, str) else ""
 
 
 


### PR DESCRIPTION
## Summary
- handle potential non-string return from `get_auth_cookie`
- guard `is_token_authenticated` against invalid token types

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6887657a10bc832385ab5ca84537e5ca