### PR TITLE
Remove dropdown from active timers

### DIFF
--- a/app.py
+++ b/app.py
@@ -1572,7 +1572,6 @@ def main():
 
         active_timer_count = sum(1 for running in st.session_state.timers.values() if running)
         with st.sidebar:
- bkcpsj-codex/fix-indentation-errors-in-app.py
             st.write(f"**Active Timers ({active_timer_count})**")
             if active_timer_count == 0:
                 st.write("No active timers")
@@ -1596,32 +1595,8 @@ def main():
                                 if st.button("Stop", key=f"summary_stop_{task_key}"):
                                     stop_active_timer(engine, task_key)
 
-            with st.expander(f"Active Timers ({active_timer_count})", expanded=active_timer_count > 0):
-                if active_timer_count == 0:
-                    st.write("No active timers")
-                else:
-                    for task_key, is_running in st.session_state.timers.items():
-                        if is_running and task_key in st.session_state.timer_start_times:
-                            parts = task_key.split('_')
-                            if len(parts) >= 3:
-                                book_title = '_'.join(parts[:-2])
-                                stage_name = parts[-2]
-                                user_name = parts[-1]
-                                start_time = st.session_state.timer_start_times[task_key]
-                                elapsed_seconds = calculate_timer_elapsed_time(start_time)
-                                elapsed_str = format_seconds_to_time(elapsed_seconds)
-                                user_display = user_name if user_name and user_name != "Not set" else "Unassigned"
-
-                                timer_col1, timer_col2 = st.columns([3, 1])
-                                with timer_col1:
-                                    st.write(f"**{book_title} - {stage_name} ({user_display})**: {elapsed_str}")
-                                with timer_col2:
-                                    if st.button("Stop", key=f"summary_stop_{task_key}"):
-                                        stop_active_timer(engine, task_key)
- main
-
-        if st.button("Refresh Active Timers", key="refresh_active_timers_sidebar", type="secondary"):
-            st.rerun()
+            if st.button("Refresh Active Timers", key="refresh_active_timers_sidebar", type="secondary"):
+                st.rerun()
 
  
 


### PR DESCRIPTION
## Summary
- remove the expander around the sidebar active timers list
- relocate the Active Timers refresh button to the sidebar

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888ac85af4c832380c82ca6a359aeb9