### PR TITLE
Fix indentation errors in app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -2516,7 +2516,6 @@ def main():
                                                             st.rerun()
 
                                                     with timer_row2_col2:
-                                                    with timer_row1_col4:
                                                         if st.button("Stop", key=f"stop_{task_key}"):
                                                             final_time = elapsed_seconds
 


### PR DESCRIPTION
## Summary
- correct indentation near timer control logic
- move the Stop button to the same row as Pause/Resume

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6888c818cb2883238d684da4f8b35c15