### PR TITLE
Update progress bar colours and button hover text

### DIFF
--- a/app.py
+++ b/app.py
@@ -1546,12 +1546,19 @@ def main():
     /* Consistent button styling */
     .stButton > button, .stDownloadButton > button {
         background-color: #EB5D0C;
-        color: white;
+        color: #ffffff;
         border: none;
     }
-    .stButton > button:hover, .stDownloadButton > button:hover {
+    .stButton > button:hover, .stDownloadButton > button:hover,
+    .stButton > button:active, .stDownloadButton > button:active,
+    .stButton > button:focus, .stDownloadButton > button:focus {
         background-color: #2AA395;
-        color: white;
+        color: #ffffff;
+    }
+
+    /* Custom progress bar colour */
+    div[data-testid="stProgress"] div[data-testid="stProgressBar"] > div {
+        background-color: #2AA395;
     }
     
     </style>
@@ -1559,6 +1566,7 @@ def main():
         unsafe_allow_html=True,
     )
 
+    st.image("BLP_head.png", width=150)
     st.title("Book Production Time Tracking")
     st.markdown("Track time spent on different stages of book production with detailed stage-specific analysis.")
 


### PR DESCRIPTION
## Summary
- change button hover text color to `#ffffff`
- style Streamlit progress bars to match custom green

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6888e5d10e4c832393a6c7c7d2af5b8d