### PR TITLE
Fix sidebar color for dark theme

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,19 +25,29 @@ st.markdown("""
     </style>
 
     <script>
-    // Wait for Streamlit to finish rendering
+    // Update sidebar background variable whenever the theme changes
     window.addEventListener('DOMContentLoaded', function () {
         const sidebar = document.querySelector('[data-testid="stSidebar"]');
         if (!sidebar) return;
 
-        const currentBg = getComputedStyle(sidebar).backgroundColor;
+        const updateColor = () => {
+            const bg = getComputedStyle(sidebar).backgroundColor;
+            document.documentElement.style.setProperty('--secondary-background-color', bg);
+        };
 
-        // Define your dark theme match colour (adjust as needed)
-        const darkThemeBg = "rgb(38, 39, 48)";  // #262730
+        // Initial set
+        updateColor();
 
-        if (currentBg === darkThemeBg) {
-            document.documentElement.style.setProperty('--secondary-background-color', darkThemeBg);
-        }
+        // Observe theme or style changes on the document and sidebar
+        const observer = new MutationObserver(updateColor);
+        observer.observe(document.documentElement, {
+            attributes: true,
+            attributeFilter: ['data-theme', 'class', 'style']
+        });
+        observer.observe(sidebar, {
+            attributes: true,
+            attributeFilter: ['class', 'style']
+        });
     });
     </script>
 """, unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- update script to dynamically set `--secondary-background-color`
  whenever the theme changes so the sidebar matches the dark theme

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_688a39e9db508323b846fc642f1e55b1