### PR TITLE
Fix sidebar color to use theme variable

### DIFF
--- a/app.py
+++ b/app.py
@@ -1653,13 +1653,10 @@ def main():
         padding: 0 0.5rem;
     }
    /* Sidebar uses Streamlit secondary background */
-[data-testid="stSidebar"],
 section[data-testid="stSidebar"] > div:first-child {
-    background-color: var(--secondary-background-color) !important;
+    background-color: var(--secondary-background-color);
 }
 
-
-    }
 
     /* Consistent button styling */
     .stButton > button, .stDownloadButton > button {


### PR DESCRIPTION
## Summary
- tweak sidebar CSS to use theme `secondary-background-color`

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b187b0e108323b729f72a67d53a00