### PR TITLE
Fix duplicate UI keys and use theme color

### DIFF
--- a/app.py
+++ b/app.py
@@ -1653,19 +1653,23 @@ def main():
         padding: 0 0.5rem;
     }
    /* Sidebar uses Streamlit secondary background */
-[data-testid="stSidebar"],
 section[data-testid="stSidebar"] > div:first-child {
-    background-color: var(--secondary-background-color) !important;
+    background-color: var(--secondary-background-color);
 }
 
-
-    }
 
     /* Consistent button styling */
     .stButton > button, .stDownloadButton > button {
         background-color: #EB5D0C;
         color: #ffffff;
         border: none;
+    }
+    button[data-testid="stBaseButton-secondary"],
+    button[data-testid="stBaseButton-secondary"]:hover,
+    button[data-testid="stBaseButton-secondary"]:active,
+    button[data-testid="stBaseButton-secondary"]:focus,
+    button[data-testid="stBaseButton-secondary"]:disabled {
+        color: #ffffff !important;
     }
     .stButton > button:hover, .stDownloadButton > button:hover,
     .stButton > button:active, .stDownloadButton > button:active,
@@ -2355,8 +2359,12 @@ button.st-emotion-cache-1h08hrp.e1e4lema2:disabled {
 
                                         # Create a summary for the expander title showing all users and their progress
                                         stage_summary_parts = []
+                                        summary_users = set()
                                         for idx, user_task in user_aggregated.iterrows():
                                             user_name = user_task['User']
+                                            if user_name in summary_users:
+                                                continue
+                                            summary_users.add(user_name)
                                             actual_time = user_task['Time spent (s)']
 
                                             # Get estimated time from the database for this specific user/stage combination
@@ -2402,9 +2410,14 @@ button.st-emotion-cache-1h08hrp.e1e4lema2:disabled {
                                             st.session_state[stage_expanded_key] = stage_has_active_timer
 
                                         with st.expander(expander_title, expanded=st.session_state[stage_expanded_key]):
+                                            processed_tasks = set()
                                             # Show one task per user for this stage
                                             for idx, user_task in user_aggregated.iterrows():
                                                 user_name = user_task['User']
+                                                task_key = f"{book_title}_{stage_name}_{user_name}"
+                                                if task_key in processed_tasks:
+                                                    continue
+                                                processed_tasks.add(task_key)
                                                 actual_time = user_task['Time spent (s)']
                                                 task_key = f"{book_title}_{stage_name}_{user_name}"
 


### PR DESCRIPTION
## Summary
- ensure duplicate user assignments don't render multiple times
- skip rendering repeated tasks to avoid Streamlit key conflicts
- keep sidebar color synced with theme secondary background
- force sidebar timer refresh button text to stay white

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b187b0e108323b729f72a67d53a00