### PR TITLE
Add time widget to sidebar

### DIFF
--- a/app.py
+++ b/app.py
@@ -801,6 +801,17 @@ def display_active_timers_sidebar(engine):
     """Display running timers in the sidebar on every page."""
     active_timer_count = sum(1 for running in st.session_state.timers.values() if running)
     with st.sidebar:
+        components.html(
+            """
+            <a href="https://time.is/Kings_Lynn" id="time_is_link" rel="nofollow" style="font-size:20px;color:032424">Time in Kings Lynn:</a>
+            <span id="Kings_Lynn_z716" style="font-size:20px;color:032424"></span>
+            <script src="//widget.time.is/t.js"></script>
+            <script>
+            time_is_widget.init({Kings_Lynn_z716:{}});
+            </script>
+            """,
+            height=70,
+        )
         st.write(f"**Active Timers ({active_timer_count})**")
         if active_timer_count == 0:
             st.write("No active timers")


### PR DESCRIPTION
## Summary
- show current time in Kings Lynn in the sidebar

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_688c7b9fddec832380e81fe0a7bb3cd0