### PR TITLE
Update sidebar clock text color

### DIFF
--- a/app.py
+++ b/app.py
@@ -801,32 +801,33 @@ def display_active_timers_sidebar(engine):
     """Display running timers in the sidebar on every page."""
     active_timer_count = sum(1 for running in st.session_state.timers.values() if running)
     with st.sidebar:
+        text_color = st.get_option("theme.textColor") or "#000000"
         components.html(
-            """
-           <div id="bst-time" style="
+            f"""
+           <div id='bst-time' style="
     font-family: 'Source Sans', sans-serif;
     font-size: 28px;
-    color: var(--text-color);
+    color: {text_color};
     max-height: 50px;
     overflow: hidden;
 "></div>
 
 <script>
-function updateBSTTime() {
+function updateBSTTime() {{
     const now = new Date();
     const bstOffset = 60; // BST = UTC+1
     const bstDate = new Date(now.getTime() + bstOffset * 60000);
 
-    const options = {
+    const options = {{
         hour: '2-digit',
         minute: '2-digit',
         second: '2-digit',
         hour12: false,
-    };
+    }};
     const timeString = bstDate.toLocaleTimeString('en-GB', options);
 
     document.getElementById('bst-time').textContent = timeString;
-}
+}}
 
 setInterval(updateBSTTime, 1000);
 updateBSTTime();


### PR DESCRIPTION
## Summary
- load Streamlit `theme.textColor` and use it for the sidebar clock

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c8857f0fc8323badc550db5b89a55