### PR TITLE
Remove unsupported key argument from Streamlit components

### DIFF
--- a/app.py
+++ b/app.py
@@ -868,7 +868,6 @@ if (!paused) {{
 </script>
 """,
                                 height=45,
-                                key=sidebar_timer_id,
                             )
                         with col2:
                             pause_label = "Resume" if paused else "Pause"
@@ -2699,7 +2698,6 @@ section[data-testid="stSidebar"] > div:first-child {
                                                             paused,
                                                         ),
                                                         height=40,
-                                                        key=timer_id,
 
                                                     )
 


### PR DESCRIPTION
## Summary
- remove unsupported `key` parameters from `components.html` calls to prevent runtime errors in sidebar timers

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68a2f98206bc832389b20359d86bf2ae