### PR TITLE
Fix duplicate reassign widget keys

### DIFF
--- a/app.py
+++ b/app.py
@@ -2571,10 +2571,8 @@ section[data-testid="stSidebar"] > div:first-child {
                                                     except ValueError:
                                                         current_index = 0  # Default to "Not set"
 
-                                                    # Include the row index so the key is always unique
+                                                    # Use row index and user name so the key is always unique
                                                     selectbox_key = f"reassign_{book_title}_{stage_name}_{user_name}_{idx}"
-                                                    # Include user_name in key to avoid duplicate elements for the same stage
-                                                    selectbox_key = f"reassign_{book_title}_{stage_name}_{user_name}"
                                                     new_user = st.selectbox(
                                                         f"User for {stage_name}:",
                                                         user_options,
@@ -2701,10 +2699,7 @@ section[data-testid="stSidebar"] > div:first-child {
                                                                         del st.session_state[key]
 
                                                                 # Store success message instead of immediate refresh
-                                                                success_key = (
-                                                                    f"reassign_success_{book_title}_{stage_name}_{user_name}_{idx}"
-                                                                    f"reassign_success_{book_title}_{stage_name}_{user_name}"
-                                                                )
+                                                                success_key = f"reassign_success_{book_title}_{stage_name}_{user_name}_{idx}"
                                                                 st.session_state[success_key] = (
                                                                     f"User reassigned from {current_user} to {new_user}"
                                                                 )
@@ -3096,7 +3091,6 @@ section[data-testid="stSidebar"] > div:first-child {
 
                                             # User reassignment success message
                                             reassign_success_key = f"reassign_success_{book_title}_{stage_name}_{user_name}_{idx}"
-                                            reassign_success_key = f"reassign_success_{book_title}_{stage_name}_{user_name}"
                                             if reassign_success_key in st.session_state:
                                                 st.success(st.session_state[reassign_success_key])
                                                 del st.session_state[reassign_success_key]


### PR DESCRIPTION
## Summary
- avoid Streamlit duplicate-element errors by including row index in reassign selectbox keys
- track reassignment success messages per row using unique keys

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a30243b5bc8323a93fbafabe0efed3