### PR TITLE
Remove bold formatting from active timer display

### DIFF
--- a/app.py
+++ b/app.py
@@ -846,7 +846,7 @@ def display_active_timers_sidebar(engine):
     """Display running timers in the sidebar on every page."""
     active_timer_count = sum(1 for running in st.session_state.timers.values() if running)
     with st.sidebar:
-        st.write(f"**Active Timers ({active_timer_count})**")
+        st.write(f"Active Timers ({active_timer_count})")
         if active_timer_count == 0:
             st.write("No active timers")
         else:
@@ -917,7 +917,7 @@ resizeIframe();
 if (!paused) {{
   setInterval(function() {{
     elapsed += 1;
-    elem.innerHTML = "{book_title} - {stage_name} ({user_display}):" + fmt(elapsed) + "</strong>/{estimate_str} - {status_text}";
+    elem.innerHTML = "{book_title} - {stage_name} ({user_display}): " + fmt(elapsed) + "{estimate_str} - {status_text}";
     resizeIframe();
   }}, 1000);
 }}
@@ -1413,7 +1413,7 @@ def render_basic_js_timer(timer_id, status_label, elapsed_seconds, paused):
 <style>
 body {{ font-family: 'Noto Sans', sans-serif; }}
 </style>
-<div id='{timer_id}'><strong>{status_label}</strong> ({elapsed_str})</div>
+<div id='{timer_id}'>{status_label} ({elapsed_str})</div>
 <script>
 var elem = document.getElementById('{timer_id}');
 function updateThemeStyles() {{
@@ -1435,7 +1435,7 @@ function fmt(sec) {{
 if (!paused) {{
   setInterval(function() {{
     elapsed += 1;
-    elem.innerHTML = "<strong>{status_label}</strong> (" + fmt(elapsed) + ")";
+    elem.innerHTML = "{status_label} (" + fmt(elapsed) + ")";
   }}, 1000);
 }}
 </script>


### PR DESCRIPTION
## Summary
- Display active timers without bold styling in sidebar
- Render basic timers with plain status labels

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a315e6cf1c8323aa7a9be8363262ef