### PR TITLE
Organize active timer text over two lines

### DIFF
--- a/app.py
+++ b/app.py
@@ -886,7 +886,7 @@ body {{
   font-weight: bold;
 }}
 </style>
-<div id='{sidebar_timer_id}' class='timer-text'>{book_title} - {stage_name} ({user_display}): {elapsed_str}/{estimate_str} - {status_text}</div>
+<div id='{sidebar_timer_id}' class='timer-text'>{book_title} - {stage_name} ({user_display}):<br>{elapsed_str}/{estimate_str} - {status_text}</div>
 <script>
 var elem = document.getElementById('{sidebar_timer_id}');
 function updateThemeStyles() {{
@@ -916,7 +916,7 @@ resizeIframe();
 if (!paused) {{
   setInterval(function() {{
     elapsed += 1;
-    elem.innerHTML = "{book_title} - {stage_name} ({user_display}):" + fmt(elapsed) + "/{estimate_str} - {status_text}";
+    elem.innerHTML = "{book_title} - {stage_name} ({user_display}):<br>" + fmt(elapsed) + "/{estimate_str} - {status_text}";
     resizeIframe();
   }}, 1000);
 }}


### PR DESCRIPTION
## Summary
- Display active timer text on separate lines for task description and timing details.

## Testing
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a326a19360832385d3cfb2fc162aab