### PR TITLE
Eliminate residual spacing above app title

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,44 +13,108 @@ from sqlalchemy.exc import IntegrityError
 
 st.set_page_config(page_title="Book Production Time Tracking", page_icon="favicon.png")
 
-st.markdown(
-    """
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,200..900;1,200..900&display=swap" rel="stylesheet">
-""",
-    unsafe_allow_html=True,
-)
-
-st.markdown(
-    """
-    <style>
-        [data-testid="stSidebar"] {
-            resize: horizontal;
-            overflow: auto;
-        }
-    </style>
-    """,
-    unsafe_allow_html=True,
-)
-
-# Set default sidebar width via JavaScript so users can still resize it
 components.html(
     """
     <script>
-    const sidebar = window.parent.document.querySelector('section[data-testid="stSidebar"]');
-    if (sidebar) {
-        if (window.innerWidth <= 768) {
-            sidebar.style.width = '100%';
-        } else {
-            sidebar.style.width = '45%';
+    (function() {
+        const doc = window.parent.document;
+        const head = doc.head;
+
+        // Hide this component's container so it doesn't affect layout
+        const frame = window.frameElement;
+        if (frame && frame.parentElement) {
+            frame.parentElement.style.display = 'none';
         }
-    }
-</script>
+
+        // Load Google Fonts
+        const link1 = doc.createElement('link');
+        link1.rel = 'preconnect';
+        link1.href = 'https://fonts.googleapis.com';
+        head.appendChild(link1);
+
+        const link2 = doc.createElement('link');
+        link2.rel = 'preconnect';
+        link2.href = 'https://fonts.gstatic.com';
+        link2.crossOrigin = 'anonymous';
+        head.appendChild(link2);
+
+        const link3 = doc.createElement('link');
+        link3.rel = 'stylesheet';
+        link3.href = 'https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,200..900;1,200..900&display=swap';
+        head.appendChild(link3);
+
+        // Global styles and resizable sidebar
+        const style = doc.createElement('style');
+        style.textContent = `
+[data-testid="stSidebar"] { resize: horizontal; overflow: auto; }
+
+.main .block-container {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+}
+.stExpander > div:first-child {
+    padding: 0.5rem 0;
+}
+.element-container {
+    margin-bottom: 0.5rem;
+}
+div[data-testid="column"] {
+    padding: 0 0.5rem;
+}
+section[data-testid="stSidebar"] > div:first-child {
+    background-color: var(--secondary-background-color);
+}
+.stButton > button, .stDownloadButton > button {
+    background-color: #EB5D0C;
+    color: #ffffff;
+    border: none;
+}
+button[data-testid="stBaseButton-secondary"],
+button[data-testid="stBaseButton-secondary"]:hover,
+button[data-testid="stBaseButton-secondary"]:active,
+button[data-testid="stBaseButton-secondary"]:focus,
+button[data-testid="stBaseButton-secondary"]:disabled {
+    color: #ffffff !important;
+    background-color: #EB5D0C !important;
+    border: none !important;
+}
+.stButton > button:hover, .stDownloadButton > button:hover,
+.stButton > button:active, .stDownloadButton > button:active,
+.stButton > button:focus, .stDownloadButton > button:focus,
+.stButton > button:disabled, .stDownloadButton > button:disabled {
+    background-color: #2AA395;
+    color: #ffffff;
+}
+div[data-testid="stProgress"] div[data-testid="stProgressBar"] > div {
+    background-color: #2AA395 !important;
+}
+div[data-testid="stTabs"] button[data-baseweb="tab"]:hover {
+    color: #EB5D0C;
+}
+div[data-testid="stTabs"] button[data-baseweb="tab"][aria-selected="true"] {
+    color: #EB5D0C;
+}
+`;
+        head.appendChild(style);
+
+        // Set default sidebar width so users can still resize it
+        const sidebar = doc.querySelector('section[data-testid="stSidebar"]');
+        if (sidebar) {
+            if (window.innerWidth <= 768) {
+                sidebar.style.width = '100%';
+            } else {
+                sidebar.style.width = '45%';
+            }
+        }
+    })();
+    </script>
 
     """,
     height=0,
 )
+
 
 # Set BST timezone (UTC+1)
 BST = timezone(timedelta(hours=1))
@@ -1776,74 +1840,6 @@ def main():
     if not engine:
         st.error("Could not connect to database. Please check your configuration.")
         return
-
-    # Add custom CSS to reduce padding and margins
-    st.markdown(
-        """
-    <style>
-    .main .block-container {
-        padding-top: 1rem;
-        padding-bottom: 1rem;
-        padding-left: 1rem;
-        padding-right: 1rem;
-    }
-    .stExpander > div:first-child {
-        padding: 0.5rem 0;
-    }
-    .element-container {
-        margin-bottom: 0.5rem;
-    }
-    div[data-testid="column"] {
-        padding: 0 0.5rem;
-    }
-   /* Sidebar uses Streamlit secondary background */
-section[data-testid="stSidebar"] > div:first-child {
-    background-color: var(--secondary-background-color);
-}
-
-
-    /* Consistent button styling */
-    .stButton > button, .stDownloadButton > button {
-        background-color: #EB5D0C;
-        color: #ffffff;
-        border: none;
-    }
-    button[data-testid="stBaseButton-secondary"],
-    button[data-testid="stBaseButton-secondary"]:hover,
-    button[data-testid="stBaseButton-secondary"]:active,
-    button[data-testid="stBaseButton-secondary"]:focus,
-    button[data-testid="stBaseButton-secondary"]:disabled {
-        color: #ffffff !important;
-        background-color: #EB5D0C !important;
-        border: none !important;
-    }
-    .stButton > button:hover, .stDownloadButton > button:hover,
-    .stButton > button:active, .stDownloadButton > button:active,
-    .stButton > button:focus, .stDownloadButton > button:focus,
-    .stButton > button:disabled, .stDownloadButton > button:disabled {
-
-        background-color: #2AA395;
-        color: #ffffff;
-    }
-
-    /* Custom progress bar colour */
-    div[data-testid="stProgress"] div[data-testid="stProgressBar"] > div {
-        background-color: #2AA395 !important;
-    }
-
-    /* Style tabs with brand colour when active or hovered */
-    div[data-testid="stTabs"] button[data-baseweb="tab"]:hover {
-        color: #EB5D0C;
-    }
-    div[data-testid="stTabs"] button[data-baseweb="tab"][aria-selected="true"] {
-        color: #EB5D0C;
-    }
-    
-
-    </style>
-    """,
-        unsafe_allow_html=True,
-    )
 
     st.title("Book Production Time Tracking")
     st.markdown("Track time spent on different stages of book production with detailed stage-specific analysis.")


### PR DESCRIPTION
## Summary
- Hide initialization component so it doesn't take up layout space
- Move global styles and sidebar logic into same zero-height component

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a489817f048323adcd0d538bd87068