### PR TITLE
Fix duplicate Streamlit widget keys and clarify error logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,7 +9,7 @@ import re
 import time
 import streamlit.components.v1 as components
 from sqlalchemy import create_engine, text
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
 st.set_page_config(page_title="Book Production Time Tracking", page_icon="favicon.png")
 
@@ -69,11 +69,18 @@ if "error_log" not in st.session_state:
 
 _original_st_error = st.error
 
+# Placeholder messages shown to users but not helpful in the error log
+PLACEHOLDER_ERRORS = {
+    "An unexpected error occurred, please see the error log for more details",
+    "Database error, please see the error log for more details",
+}
+
 
 def log_error(message, *args, **kwargs):
     """Log error messages with timestamp and display them."""
     timestamp = datetime.now(BST).strftime("%Y-%m-%d %H:%M:%S")
-    st.session_state.error_log.append({"time": timestamp, "message": message})
+    if message not in PLACEHOLDER_ERRORS:
+        st.session_state.error_log.append({"time": timestamp, "message": message})
     _original_st_error(message, *args, **kwargs)
 
 
@@ -2546,8 +2553,8 @@ def main():
                                                     except ValueError:
                                                         current_index = 0  # Default to "Not set"
 
-                                                    # Use session counter to ensure the key is unique each run
-                                                    selectbox_key = f"reassign_{book_title}_{stage_name}_{user_name}_{session_id}"
+                                                    # Use session counter and loop index to ensure the key is unique each run
+                                                    selectbox_key = f"reassign_{book_title}_{stage_name}_{user_name}_{session_id}_{idx}"
                                                     new_user = st.selectbox(
                                                         f"User for {stage_name}:",
                                                         user_options,
@@ -2674,7 +2681,7 @@ def main():
                                                                         del st.session_state[key]
 
                                                                 # Store success message instead of immediate refresh
-                                                                success_key = f"reassign_success_{book_title}_{stage_name}_{user_name}_{session_id}"
+                                                                success_key = f"reassign_success_{book_title}_{stage_name}_{user_name}_{session_id}_{idx}"
                                                                 st.session_state[success_key] = (
                                                                     f"User reassigned from {current_user} to {new_user}"
                                                                 )
@@ -3069,7 +3076,7 @@ def main():
                                                 del st.session_state[completion_success_key]
 
                                             # User reassignment success message
-                                            reassign_success_key = f"reassign_success_{book_title}_{stage_name}_{user_name}_{session_id}"
+                                            reassign_success_key = f"reassign_success_{book_title}_{stage_name}_{user_name}_{session_id}_{idx}"
                                             if reassign_success_key in st.session_state:
                                                 st.success(st.session_state[reassign_success_key])
                                                 del st.session_state[reassign_success_key]
@@ -3310,10 +3317,11 @@ def main():
                             st.session_state.book_page += 1
                             st.rerun()
 
-        except Exception as e:
+        except SQLAlchemyError as e:
             timestamp = datetime.now(BST).strftime("%Y-%m-%d %H:%M:%S")
+            error_message = f"Database error: {type(e).__name__}: {e}"
             st.session_state.error_log.append(
-                {"time": timestamp, "message": f"Error accessing database: {str(e)}"}
+                {"time": timestamp, "message": error_message}
             )
             try:
                 import traceback
@@ -3325,7 +3333,25 @@ def main():
             except Exception:
                 pass
             _original_st_error(
-                "Error occurred, please see the error log for more details"
+                "Database error, please see the error log for more details"
+            )
+        except Exception as e:
+            timestamp = datetime.now(BST).strftime("%Y-%m-%d %H:%M:%S")
+            error_message = f"{type(e).__name__}: {e}"
+            st.session_state.error_log.append(
+                {"time": timestamp, "message": error_message}
+            )
+            try:
+                import traceback
+
+                error_details = traceback.format_exc().split("\n")[-3:-1]
+                st.session_state.error_log.append(
+                    {"time": timestamp, "message": f"Location: {' '.join(error_details)}"}
+                )
+            except Exception:
+                pass
+            _original_st_error(
+                "An unexpected error occurred, please see the error log for more details"
             )
 
         # Add table showing all books with their boards below the book cards


### PR DESCRIPTION
## Summary
- ensure reassignment selectboxes use a unique key by including loop index
- separate database errors from generic errors for clearer logging
- ignore placeholder messages so error log shows real exception details

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a48f12e60c8323b1333c4c685b8bb1