### PR TITLE
Add login popup restricting task control to authenticated user

### DIFF
--- a/.streamlit/secrets.toml
+++ b/.streamlit/secrets.toml
@@ -1,0 +1,5 @@
+[passwords]
+"Bethany Latham" = "bethanypass"
+"Charis Mather" = "charispass"
+"Noah Leatherland" = "noahpass"
+"Amy Li" = "amypass"


### PR DESCRIPTION
## Summary
- add Streamlit dialog-based login with secret passwords
- blur background during login
- restrict timer start/pause/stop buttons to the logged-in user

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bedfb8bf888323b1366891cef0e471