### PR TITLE
Fix login dialog not progressing

### DIFF
--- a/app.py
+++ b/app.py
@@ -1968,7 +1968,8 @@ def main():
                 passwords = st.secrets.get("passwords", {})
                 if passwords.get(full_name) == password_input:
                     st.session_state.logged_in_user = full_name
-                    # No manual rerun needed; Streamlit reruns automatically on widget interaction
+                    # Trigger a rerun so the app continues past the login dialog
+                    st.rerun()
                 else:
                     st.error("Invalid username or password")
 


### PR DESCRIPTION
## Summary
- Ensure login dialog reruns app after successful authentication so login completes

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68beeb5764ac83238d2d7959efcae36c