### PR TITLE
Fix error logging reference

### DIFF
--- a/app.py
+++ b/app.py
@@ -3541,7 +3541,7 @@ def main():
                 )
             except Exception:
                 pass
-            st.session_state._original_st_error(
+            st._original_st_error(
                 "Database error, please see the error log for more details"
             )
         except Exception as e:
@@ -3560,7 +3560,7 @@ def main():
                 )
             except Exception:
                 pass
-            st.session_state._original_st_error(
+            st._original_st_error(
                 "An unexpected error occurred, please see the error log for more details"
             )
 


### PR DESCRIPTION
## Summary
- Use original Streamlit error function directly when logging database and runtime errors

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bffcf68e98832381aebd781524e81a