### PR TITLE
feat: recognize additional upload users

### DIFF
--- a/app.py
+++ b/app.py
@@ -134,7 +134,15 @@ DESIGN_USERS_LIST = [
     "Ker Ker Lee",
     "Rob Delph",
 ]
+# Extra users that may appear in uploads but are not part of core teams
+ADDITIONAL_USERS_LIST = [
+    "Ian McMullen",
+    "Dan Scase",
+    "Harriet Williamson-Brundle",
+]
+
 ALL_USERS_LIST = EDITORIAL_USERS_LIST + DESIGN_USERS_LIST
+KNOWN_USERS_LIST = ALL_USERS_LIST + ADDITIONAL_USERS_LIST
 
 STAGE_ORDER = [
     "Editorial R&D",
@@ -151,7 +159,7 @@ STAGE_ORDER = [
 ]
 
 # Map first names (and common short forms) to full user names
-FIRST_NAME_TO_FULL = {name.split()[0].lower(): name for name in ALL_USERS_LIST}
+FIRST_NAME_TO_FULL = {name.split()[0].lower(): name for name in KNOWN_USERS_LIST}
 FIRST_NAME_TO_FULL.update({
     "beth": "Beth Latham",
     "ker ker": "Ker Ker Lee",
@@ -168,7 +176,7 @@ def normalize_user_name(name):
 
     lower = name.lower()
     # Exact match to known users
-    for full in ALL_USERS_LIST:
+    for full in KNOWN_USERS_LIST:
         if lower == full.lower():
             return full
 


### PR DESCRIPTION
## Summary
- allow parsing upload-only user names

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c28b7e89848323ac2554795233c391